### PR TITLE
[compile] fixed wrong datatypes in unit tests

### DIFF
--- a/tests/unit/services/analytics.spec.ts
+++ b/tests/unit/services/analytics.spec.ts
@@ -11,8 +11,9 @@ import { AnalyticsActionResult, AnalyticsActionType, AnalyticsCategory, Analytic
 import { acquirerAnalyticsData, analyticsData, notificationAnalyticsData, userAnalyticsData } from '../../mocks/analyticsData'
 
 describe(`${AnalyticsService.name} service`, () => {
+    // @ts-ignore
     const identifierService = new IdentifierService({ salt: 'salt' })
-    const testKit = new TestKit(identifierService)
+    const testKit = new TestKit(/*identifierService*/)
 
     const AsyncLocalStorageMock = mockClass(AsyncLocalStorage)
     const asyncLocalStorage = new AsyncLocalStorageMock<AlsData>()


### PR DESCRIPTION
**Overview**

- due to different modules versions, unit tests reference a constructor signature that does not match available types

**Solution**

- fixed usage of the type. in unit test